### PR TITLE
fix: make factory ros.env snap-agnostic

### DIFF
--- a/local-ros/ros.env
+++ b/local-ros/ros.env
@@ -3,4 +3,4 @@ export ROS_LOCALHOST_ONLY=0
 unset ROS_NAMESPACE
 unset CYCLONEDDS_URI
 export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-export FASTRTPS_DEFAULT_PROFILES_FILE=/var/snap/husarion-depthai/common/udp.xml
+unset FASTRTPS_DEFAULT_PROFILES_FILE


### PR DESCRIPTION
## Problem

The factory `ros.env` shipped at `$SNAP/usr/share/husarion-snap-common/config/ros.env` hardcoded:

```
export FASTRTPS_DEFAULT_PROFILES_FILE=/var/snap/husarion-depthai/common/udp.xml
```

That line has been present since the initial commit (Jul 2024) and ships in every tag (incl. `0.8.0`), so it leaks into **every** consuming snap (rosbot, depthai, rplidar, webui, camera).

## How it surfaced on `husarion-rplidar`

After a local build + install, `husarion-rplidar.daemon` crash-looped with no useful error — only a single application log line before each exit:

```
husarion-rplidar[…]: ros_setup.sh: Copying ros.env file to /var/snap/husarion-rplidar/common
snap.husarion-rplidar.daemon.service: Main process exited, code=exited, status=1/FAILURE
snap.husarion-rplidar.daemon.service: Failed with result 'exit-code'.
…
snap.husarion-rplidar.daemon.service: Start request repeated too quickly.
```

The crash happened **before** `launcher.sh` could log anything (no `Found serial port`, no `Running with options`), which is what made it look mysterious.

### Root cause — a startup race

`ros_setup.sh` (command-chain wrapper for the daemon) only copies the factory `ros.env` into `$SNAP_COMMON/ros.env` **as a bootstrap fallback**, when the file does not yet exist:

```sh
if [[ ! -f "$ROS_ENV_FILE" ]]; then
    log "Copying ros.env file to $SNAP_COMMON"
    cp -r ${SNAP}/usr/share/husarion-snap-common/config/ros.env ${SNAP_COMMON}/
fi
source "$ROS_ENV_FILE"   # bash -e: a bad source here kills the daemon
exec "$@"
```

On a fresh install the `daemon` (`install-mode: enable`) can start **before** the `configure` hook has regenerated `ros.env` via `configure_hook_ros.sh`. When it wins that race it hits the fallback and copies the factory file verbatim — including `FASTRTPS_DEFAULT_PROFILES_FILE=/var/snap/husarion-depthai/common/udp.xml`.

On any non-depthai host that path does not exist. FastDDS fails to load the profiles file during RMW init → the launch process exits `1` → systemd restarts → same fallback file → crash loop, until the `configure` hook finally overwrites `ros.env` with the correct, snap-local profile path (`/var/snap/husarion-rplidar/common/rmw/fastdds/udp.xml`).

That overwrite is exactly why **the daemon "spontaneously started working" a couple of minutes later** — nothing about rplidar was fixed; the configure hook simply replaced the poisoned fallback. The bug is intermittent precisely because it only bites in the race window, and self-heals on the next `snap set` / configure run.

## Fix

`unset FASTRTPS_DEFAULT_PROFILES_FILE` instead (symmetric with the existing `unset CYCLONEDDS_URI`). The fallback now yields FastDDS library defaults and never references a specific snap, so even when the daemon wins the race it comes up on sane defaults and is later reconfigured by the configure hook.

No functional change on the happy path — the authoritative `ros.env` is always written by `configure_hook_ros.sh`; only the race-window fallback content changes.

## Rollout

Consuming snaps pin a tag, so this needs a new tag (e.g. `0.8.1`) and a `source-tag` bump in each snap's template before the fix reaches built snaps.