### PR TITLE
fix: self-heal rmw/ tree on refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Shared library / staging tree for Husarion ROS 2 snaps. Pulled in by `rosbot-sna
 
 | Path | What |
 |---|---|
-| `local-ros/configure_hook_ros.sh` | Runs from the consuming snap's `configure` hook on every `snap set` / `snap unset`. Validates `ros.*` keys, resolves `ros.transport` → `RMW_IMPLEMENTATION` + profile path, writes `${SNAP_COMMON}/ros.env`. |
-| `local-ros/install_hook_ros.sh` | Runs from the consuming snap's `install` hook on first install. Sets default `ros.*` values, seeds the `${SNAP_COMMON}/rmw/` tree from the factory snapshot, drops back-compat `dds-config-*.xml` symlinks. |
-| `local-ros/utils.sh` | Shell helpers: `validate_option`, `validate_keys`, `validate_number`, `validate_regex`, `validate_path`, `validate_config_param`, `validate_ipv4_addr`, `validate_peers_list`, `check_xml_profile_type`, `log_and_echo`, `source_ros`. Sourced by every other script. |
+| `local-ros/configure_hook_ros.sh` | Runs from the consuming snap's `configure` hook on every `snap set` / `snap unset` / refresh. Re-seeds any missing `${SNAP_COMMON}/rmw/` files (`seed_rmw_tree`, self-heal for robots upgraded across the 0.5.0→0.6.0 layout change — the install hook doesn't run on refresh), validates `ros.*` keys, resolves `ros.transport` → `RMW_IMPLEMENTATION` + profile path, writes `${SNAP_COMMON}/ros.env`. |
+| `local-ros/install_hook_ros.sh` | Runs from the consuming snap's `install` hook on first install. Sets default `ros.*` values, force-seeds the `${SNAP_COMMON}/rmw/` tree from the factory snapshot (`seed_rmw_tree --force`), drops back-compat `dds-config-*.xml` symlinks. |
+| `local-ros/utils.sh` | Shell helpers: `validate_option`, `validate_keys`, `validate_number`, `validate_regex`, `validate_path`, `validate_config_param`, `validate_ipv4_addr`, `validate_peers_list`, `check_xml_profile_type`, `seed_rmw_tree`, `log_and_echo`, `source_ros`. Sourced by every other script. |
 | `local-ros/ros_setup.sh` | Sources `${SNAP_COMMON}/ros.env` then `exec`s "$@" — used as a command-chain wrapper for ROS apps. |
 | `local-ros/{start,stop,restart}_launcher.sh` | systemctl-via-snapctl thin wrappers. |
 | `local-ros/check_daemon_running.sh` | Small probe used by app commands. |

--- a/local-ros/configure_hook_ros.sh
+++ b/local-ros/configure_hook_ros.sh
@@ -10,6 +10,11 @@ source $SNAP/usr/bin/utils.sh
 
 source_ros
 
+# Self-heal: the install hook seeds rmw/ but doesn't run on refresh, so a
+# robot upgraded across the 0.5.0→0.6.0 layout change has no rmw/ tree and
+# transport resolution below would abort the refresh on a missing profile.
+seed_rmw_tree
+
 # Create the ${SNAP_COMMON}/ros.env file and export variables (for bash session running ROS2)
 ROS_ENV_FILE="${SNAP_COMMON}/ros.env"
 

--- a/local-ros/install_hook_ros.sh
+++ b/local-ros/install_hook_ros.sh
@@ -26,52 +26,9 @@ snapctl set ros.transport="udp"
 snapctl set ros.domain-id=0
 snapctl set ros.namespace="" # unset
 
-# ---------------------------------------------------------------- rmw/ tree
-#
-# Layout (since 0.6.0):
-#
-#   ${SNAP_COMMON}/rmw/
-#       fastdds/{udp,shm,udp-lo}.xml
-#       cyclonedds/udp-lo.xml
-#       zenoh/{default,shm}.json5            (dormant)
-#       zenoh-router/{default,shm}-router.json5  (dormant)
-#
-# The configure-hook reads from this layout. Tokens passed to
-# `ros.transport=…` resolve to file paths under here (see
-# configure_hook_ros.sh's case statement).
-#
-# Zenoh subdirs are populated but DORMANT: the configure-hook
-# currently rejects `ros.transport=zenoh*` tokens because
-# micro_ros_agent (in the rosbot snap) is statically linked to
-# FastDDS and motor-feedback never reaches rmw_zenoh_cpp subscribers.
-# We keep the factory configs in place so the re-enable, once
-# upstream lands a fix, is a one-line revert in configure_hook_ros.sh.
-SRC="${SNAP}/usr/share/husarion-snap-common/config/rmw"
-DST="${SNAP_COMMON}/rmw"
-mkdir -p "${DST}/fastdds" "${DST}/cyclonedds" "${DST}/zenoh" "${DST}/zenoh-router"
-
-# Copy the factory snapshot in. The install hook should always
-# have the factory-default state on first install, so we overwrite.
-# Operator edits between installs survive `snap refresh` (the
-# post-refresh hook doesn't touch these files); only a `snap remove`
-# + `snap install` cycle resets them.
-for sub in fastdds cyclonedds zenoh zenoh-router; do
-    if [ -d "${SRC}/${sub}" ]; then
-        cp -rf "${SRC}/${sub}/." "${DST}/${sub}/"
-    fi
-done
-
-# ---------------------------------------------------------------- back-compat
-#
-# Legacy flat paths (pre-0.6.0): callers that read
-# `${SNAP_COMMON}/dds-config-<token>.xml` directly keep working
-# via symlinks into the new rmw/ tree. The snap's own
-# configure_hook_ros.sh DOESN'T read these — they exist only for
-# external callers (the husarion-cockpit agent's network
-# capability auto-discovers them via enum_from_glob, third-party
-# scripts, ros2 invocations from the host bash sourcing the old
-# ros.env, etc.).
-ln -sfn rmw/fastdds/udp.xml       "${SNAP_COMMON}/dds-config-udp.xml"
-ln -sfn rmw/fastdds/shm.xml       "${SNAP_COMMON}/dds-config-shm.xml"
-ln -sfn rmw/fastdds/udp-lo.xml    "${SNAP_COMMON}/dds-config-udp-lo.xml"
-ln -sfn rmw/cyclonedds/udp-lo.xml "${SNAP_COMMON}/dds-config-udp-lo-cyclone.xml"
+# Force factory defaults on first install (configure hook re-seeds only
+# missing files on refresh, so operator edits survive). seed_rmw_tree also
+# drops the back-compat dds-config-*.xml symlinks at the legacy flat paths,
+# read by external callers (husarion-cockpit network capability, host-bash
+# ros2 sourcing the old ros.env) — the snap's own hooks don't read them.
+seed_rmw_tree --force

--- a/local-ros/utils.sh
+++ b/local-ros/utils.sh
@@ -551,6 +551,37 @@ source_ros() {
     fi
 }
 
+# Seed ${SNAP_COMMON}/rmw/ from the snap's factory snapshot. Idempotent.
+# --force overwrites (install); default copies only missing files so
+# operator edits survive (configure, on every refresh).
+seed_rmw_tree() {
+    local force=0
+    [ "${1:-}" = "--force" ] && force=1
+
+    local src="${SNAP}/usr/share/husarion-snap-common/config/rmw"
+    local dst="${SNAP_COMMON}/rmw"
+    [ -d "$src" ] || return 0
+
+    mkdir -p "${dst}/fastdds" "${dst}/cyclonedds" "${dst}/zenoh" "${dst}/zenoh-router"
+
+    local sub f name
+    for sub in fastdds cyclonedds zenoh zenoh-router; do
+        [ -d "${src}/${sub}" ] || continue
+        for f in "${src}/${sub}"/*; do
+            [ -e "$f" ] || continue
+            name=$(basename "$f")
+            if [ "$force" = "1" ] || [ ! -e "${dst}/${sub}/${name}" ]; then
+                cp -f "$f" "${dst}/${sub}/${name}"
+            fi
+        done
+    done
+
+    ln -sfn rmw/fastdds/udp.xml       "${SNAP_COMMON}/dds-config-udp.xml"
+    ln -sfn rmw/fastdds/shm.xml       "${SNAP_COMMON}/dds-config-shm.xml"
+    ln -sfn rmw/fastdds/udp-lo.xml    "${SNAP_COMMON}/dds-config-udp-lo.xml"
+    ln -sfn rmw/cyclonedds/udp-lo.xml "${SNAP_COMMON}/dds-config-udp-lo-cyclone.xml"
+}
+
 # Function to check the type of the provided XML file
 check_xml_profile_type() {
     local xml_file="$1"


### PR DESCRIPTION
## Problem

Every snap built on `husarion-snap-common` 0.6.0 fails `snap refresh` for robots upgraded from 0.5.0:

```
Run configure hook of "rosbot" snap if present (run hook "configure"):
'udp' resolves to '/var/snap/rosbot/common/rmw/fastdds/udp.xml' which doesn't exist.
```

0.6.0 moved DDS profiles from flat `dds-config-*.xml` to the `${SNAP_COMMON}/rmw/` tree, seeded by the **install** hook. The install hook only runs on first install, **not on refresh** — so a robot crossing the 0.5.0→0.6.0 boundary reaches the configure hook with no `rmw/` tree, and transport resolution aborts the refresh on a missing profile XML. Hits all consuming snaps (rosbot / rplidar / depthai / webui).

## Fix

- New `seed_rmw_tree()` in `utils.sh` — populates `${SNAP_COMMON}/rmw/` from the factory snapshot. Idempotent. `--force` overwrites (install); default copies only missing files so operator edits survive.
- `configure_hook_ros.sh` calls `seed_rmw_tree` (non-destructive) right after `source_ros`, before transport resolution → **self-heals on every refresh**.
- `install_hook_ros.sh` calls `seed_rmw_tree --force` (same factory-overwrite behaviour as before, DRY).

Single point of fix in the shared layer → fixes all consuming snaps. Once released, currently-broken robots self-heal in the same refresh that pulls this in (the new configure hook runs against the new revision's factory snapshot).

## Test
- `seed_rmw_tree` mock-tested: seeds on empty common, preserves operator edits on re-run, `--force` overwrites, back-compat symlinks created. `bash -n` clean on all three scripts.
- ⚠️ Not yet validated on HW / `snap try` — recommend one `just rebuild jazzy` loop (common via `source-type: local`) + `snap set rosbot ros.transport=udp` on a test host before merge.