### PR TITLE
fix(husarion-agent): don't preserve ownership when seeding hooks/manifests

### DIFF
--- a/husarion-agent/launcher.sh
+++ b/husarion-agent/launcher.sh
@@ -32,19 +32,23 @@ mkdir -p "$STATE_DIR" "$PANELS_OVERRIDES" "${SNAP_COMMON}/peer-certs"
 #   newer code wins (shipped > whatever was staged before).
 SEED_ROOT="${SNAP}/usr/share/husarion-agent/config-seed"
 if [ -d "$SEED_ROOT" ]; then
+    # --no-preserve=ownership: cp -a's chown of the copy to the source's uid
+    # needs CAP_CHOWN, which strict confinement's default daemon profile
+    # doesn't grant even to a root-run service — copy as the running user
+    # instead (mode/timestamps still preserved).
     for item in agent.yaml follow.yaml config; do
         if [ -e "$SEED_ROOT/$item" ] && [ ! -e "$STATE_DIR/$item" ]; then
-            cp -a "$SEED_ROOT/$item" "$STATE_DIR/$item"
+            cp -a --no-preserve=ownership "$SEED_ROOT/$item" "$STATE_DIR/$item"
         fi
     done
     if [ -d "$SEED_ROOT/hooks" ]; then
         mkdir -p "$STATE_DIR/hooks"
-        cp -a "$SEED_ROOT/hooks/." "$STATE_DIR/hooks/"
+        cp -a --no-preserve=ownership "$SEED_ROOT/hooks/." "$STATE_DIR/hooks/"
         find "$STATE_DIR/hooks" -type f -exec chmod 0755 {} +
     fi
     if [ -d "$SEED_ROOT/manifests" ]; then
         mkdir -p "$STATE_DIR/manifests"
-        cp -a "$SEED_ROOT/manifests/." "$STATE_DIR/manifests/"
+        cp -a --no-preserve=ownership "$SEED_ROOT/manifests/." "$STATE_DIR/manifests/"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- `cp -a` in `husarion-agent/launcher.sh` preserves the source's ownership on copy, which requires `CAP_CHOWN`. Strict confinement's default profile for a plain `daemon: simple` app doesn't grant it, so every start of `husarion-agent` failed with `Operation not permitted`, restart-looping until systemd gave up.
- Switch to `cp -a --no-preserve=ownership` for the `hooks/`/`manifests/`/seed-item copies — mode and timestamps are still preserved, only ownership is skipped (irrelevant once the files land in the daemon's own `$SNAP_COMMON`).

## Test plan
- [x] Reproduced live on a `snap try` install (husarion-depthai-snap): `husarion-agent.service` restart-looping on `cp: failed to preserve ownership ... Operation not permitted`.
- [x] Applied the fix directly to the running snap's launcher script and restarted the service — starts cleanly, no more EPERM.
- [ ] Full rebuild via consumer snap `just iterate` against this tag, on target hardware.